### PR TITLE
Allow passing environment to daemons via :env => Hash option

### DIFF
--- a/lib/daemon_controller.rb
+++ b/lib/daemon_controller.rb
@@ -170,6 +170,10 @@ class DaemonController
 	#  descriptors except stdin, stdout and stderr. However if there are any file
 	#  descriptors you want to keep open, specify the IO objects here. This must be
 	#  an array of IO objects.
+	#
+	# [:env]
+	#  This must be a Hash.  The hash will contain the environment variables available
+	#  to be made available to the daemon. Hash keys must be strings, not symbols.
 	def initialize(options)
 		[:identifier, :start_command, :ping_command, :pid_file, :log_file].each do |option|
 			if !options.has_key?(option)
@@ -190,6 +194,7 @@ class DaemonController
 		@daemonize_for_me = options[:daemonize_for_me]
 		@keep_ios = options[:keep_ios] || []
 		@lock_file = determine_lock_file(options, @identifier, @pid_file)
+		@env = options[:env] || {}
 	end
 	
 	# Start the daemon and wait until it can be pinged.
@@ -579,10 +584,10 @@ private
 						Config::CONFIG['bindir'],
 						Config::CONFIG['RUBY_INSTALL_NAME']
 					) + Config::CONFIG['EXEEXT']
-					pid = Process.spawn(ruby_interpreter, SPAWNER_FILE,
+					pid = Process.spawn(@env, ruby_interpreter, SPAWNER_FILE,
 						command, options)
 				else
-					pid = Process.spawn(command, options)
+					pid = Process.spawn(@env, command, options)
 				end
 			else
 				pid = safe_fork(@daemonize_for_me) do
@@ -594,6 +599,7 @@ private
 					STDIN.reopen("/dev/null", "r")
 					STDOUT.reopen(tempfile_path, "w")
 					STDERR.reopen(tempfile_path, "w")
+					ENV.update(@env)
 					exec(command)
 				end
 			end

--- a/spec/daemon_controller_spec.rb
+++ b/spec/daemon_controller_spec.rb
@@ -234,6 +234,14 @@ describe DaemonController, "#start" do
 			@controller.stop
 		end
 	end
+
+	it "receives environment variables" do
+		new_controller(:env => {'ENV_FILE' => 'spec/env_file.tmp'})
+		File.unlink('spec/env_file.tmp') if File.exist?('spec/env_file.tmp')
+		@controller.start
+		File.exist?('spec/env_file.tmp').should be_true
+		@controller.stop
+	end
 end
 
 describe DaemonController, "#stop" do

--- a/spec/echo_server.rb
+++ b/spec/echo_server.rb
@@ -61,6 +61,10 @@ if options[:pid_file]
 	end
 end
 
+if ENV['ENV_FILE']
+	options[:env_file] = File.expand_path(ENV['ENV_FILE'])
+end
+
 def main(options)
 	STDIN.reopen("/dev/null", 'r')
 	STDOUT.reopen(options[:log_file], 'a')
@@ -69,6 +73,15 @@ def main(options)
 	STDERR.sync = true
 	Dir.chdir(options[:chdir])
 	File.umask(0)
+
+	if options[:env_file]
+		File.open(options[:env_file], 'w') do |f|
+			f.write("\0")
+		end
+		at_exit do
+			File.unlink(options[:env_file]) rescue nil
+		end
+	end
 	
 	if options[:pid_file]
 		sleep(options[:wait1])


### PR DESCRIPTION
I'm spawning some daemons via rake tasks to avoid code duplication, so maybe "I'm doing it wrong".  In any case, I need to set environment vars, and I figured being able to set them was probably a useful feature.
