### PR TITLE
add license information to the gemspec

### DIFF
--- a/daemon_controller.gemspec
+++ b/daemon_controller.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
       "spec/unresponsive_daemon.rb",
       "spec/run_echo_server"
   ]
+  s.license = "MIT"
 end


### PR DESCRIPTION
This way this info can be retrieved using rubygems.org API
